### PR TITLE
build: support multi arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,26 +25,30 @@ RUN cargo install --path .
 # ---------------------------------------------------
 FROM gcr.io/distroless/cc-debian11
 
+# Set the architecture argument (arm64, i.e. aarch64 as default)
+# For amd64, i.e. x86_64, you can append a flag when invoking the cli `... --build-arg "ARCH=x86_64"`
+ARG ARCH=aarch64
+
 # libpq related (required by diesel)
-COPY --from=build /usr/lib/aarch64-linux-gnu/libpq.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libgssapi_krb5.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libldap_r-2.4.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libkrb5.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libk5crypto.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libkrb5support.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/liblber-2.4.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libsasl2.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libgnutls.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libp11-kit.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libidn2.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libunistring.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libtasn1.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libnettle.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libhogweed.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libgmp.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /usr/lib/aarch64-linux-gnu/libffi.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=build /lib/aarch64-linux-gnu/libcom_err.so* /lib/aarch64-linux-gnu/
-COPY --from=build /lib/aarch64-linux-gnu/libkeyutils.so* /lib/aarch64-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libpq.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libgssapi_krb5.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libldap_r-2.4.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libkrb5.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libk5crypto.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libkrb5support.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/liblber-2.4.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libsasl2.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libgnutls.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libp11-kit.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libidn2.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libunistring.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libtasn1.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libnettle.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libhogweed.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libgmp.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /usr/lib/${ARCH}-linux-gnu/libffi.so* /usr/lib/${ARCH}-linux-gnu/
+COPY --from=build /lib/${ARCH}-linux-gnu/libcom_err.so* /lib/${ARCH}-linux-gnu/
+COPY --from=build /lib/${ARCH}-linux-gnu/libkeyutils.so* /lib/${ARCH}-linux-gnu/
 
 # Application files
 COPY --from=build /usr/local/cargo/bin/codefee-works-api /usr/local/bin/codefee-works-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cargo install --path .
 FROM gcr.io/distroless/cc-debian11
 
 # Set the architecture argument (arm64, i.e. aarch64 as default)
-# For amd64, i.e. x86_64, you can append a flag when invoking the cli `... --build-arg "ARCH=x86_64"`
+# For amd64, i.e. x86_64, you can append a flag when invoking the build `... --build-arg "ARCH=x86_64"`
 ARG ARCH=aarch64
 
 # libpq related (required by diesel)

--- a/README.md
+++ b/README.md
@@ -10,15 +10,21 @@ Easiest way to spin up a working sample of this repo is via Docker Compose
 
 To spin up the entire stack on local, just run the following command (depending on your target architecture).
 
-For arm64 / aarch64 / M1 Mac for example, it is supported by default
+1. arm64 / aarch64, e.g. M1 Mac,
 
-```
+```bash
+# It is supported by default. You can simply run
+docker-compose up
+
+# You may also specify it explicitly
+docker-compose build --build-arg "ARCH=aarch64"
 docker-compose up
 ```
 
-For amd84 / x86_64 / Intel chips for example,
+2. amd84 / x86_64, e.g. Intel chips,
 
-```
+```bash
+# You need to specify the ARCH argument accordingly
 docker-compose build --build-arg "ARCH=x86_64"
 docker-compose up
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,18 @@ Easiest way to spin up a working sample of this repo is via Docker Compose
 
 ## 2.1 Docker Compose
 
-To spin up the entire stack on local, just run the command
+To spin up the entire stack on local, just run the following command (depending on your target architecture).
+
+For arm64 / aarch64 / M1 Mac for example, it is supported by default
 
 ```
+docker-compose up
+```
+
+For amd84 / x86_64 / Intel chips for example,
+
+```
+docker-compose build --build-arg "ARCH=x86_64"
 docker-compose up
 ```
 


### PR DESCRIPTION
This change includes a flag option to specify target machine architecture for the Docker build.

Here are some examples to spin up the stack

1. arm64 / aarch64, e.g. M1 Mac,
``` bash
# It is supported by default. You can simply run
docker-compose up

# You may also specify it explicitly
docker-compose build --build-arg "ARCH=aarch64"
docker-compose up
```

2. amd84 / x86_64, e.g. Intel chips, 
``` bash
# You need to specify the ARCH argument accordingly
docker-compose build --build-arg "ARCH=x86_64"
docker-compose up
```